### PR TITLE
Fix empty body after docstring stripping

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -220,6 +220,10 @@ class AST_Tests(unittest.TestCase):
                 # This also must not crash:
                 ast.parse(tree, optimize=2)
 
+    def test_compile_after_docstring_removal(self):
+        tree = ast.parse('"""doc"""')
+        compile(tree, '<string>', 'exec', optimize=2)
+
     def test_slice(self):
         slc = ast.parse("x[::]").body[0].value.slice
         self.assertIsNone(slc.upper)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-06-01-ast-pass.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-06-01-ast-pass.rst
@@ -1,0 +1,2 @@
+Ensure ``compile()`` succeeds when docstring stripping leaves an empty body
+by inserting a ``pass`` statement during AST preprocessing.

--- a/Python/ast_preprocess.c
+++ b/Python/ast_preprocess.c
@@ -441,8 +441,19 @@ astfold_body(asdl_stmt_seq *stmts, PyArena *ctx_, _PyASTPreprocessState *state)
     int docstring = _PyAST_GetDocString(stmts) != NULL;
     if (docstring && (state->optimize >= 2)) {
         /* remove the docstring */
+        stmt_ty st = (stmt_ty)asdl_seq_GET(stmts, 0);
         if (!stmt_seq_remove_item(stmts, 0)) {
             return 0;
+        }
+        if (asdl_seq_LEN(stmts) == 0) {
+            stmt_ty pass_stmt = _PyAST_Pass(st->lineno, st->col_offset,
+                                            st->end_lineno, st->end_col_offset,
+                                            ctx_);
+            if (!pass_stmt) {
+                return 0;
+            }
+            stmts->size++;
+            asdl_seq_SET(stmts, stmts->size - 1, pass_stmt);
         }
         docstring = 0;
     }


### PR DESCRIPTION
## Summary
- prevent docstring removal from leaving an empty AST body by inserting a `pass`
- add regression test ensuring `ast.parse` followed by `compile(optimize=2)` succeeds
- document the fix in the NEWS file

## Testing
- `./python -OO -m test -j2 test_ast`


------
https://chatgpt.com/codex/tasks/task_e_688de417dbac832d99b1cf0fca84b691