### PR TITLE
gh-149221: Fix binomialvariate() raising ValueError when random() returns 0.0

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -836,7 +836,11 @@ class Random(_random.Random):
             if not c:
                 return x
             while True:
-                y += _floor(_log2(random()) / c) + 1
+                try:
+                    y += _floor(_log2(random()) / c) + 1
+                except ValueError:
+                    # Reject case where random() returned 0.0
+                    continue
                 if y > n:
                     return x
                 x += 1

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1154,6 +1154,17 @@ class TestDistributions(unittest.TestCase):
         self.assertTrue(89_000_000 <= B(100_000_000, 0.9) <= 91_000_000)
 
 
+    @unittest.mock.patch('random.Random.random')
+    def test_binomialvariate_zero_random(self, random_mock):
+        # gh-149221: random() can legitimately return 0.0 (its documented
+        # range is [0.0, 1.0)).  The BG geometric branch must reject that
+        # draw instead of raising "math domain error" from log2(0.0).
+        seq = iter([0.0])
+        random_mock.side_effect = lambda: next(seq, 0.5)
+        # n*p == 2.0 < 10.0 selects the BG geometric method.
+        self.assertIn(random.binomialvariate(20, 0.1), range(21))
+
+
     def test_von_mises_range(self):
         # Issue 17149: von mises variates were not consistently in the
         # range [0, 2*PI].

--- a/Misc/NEWS.d/next/Library/2026-06-06-18-57-00.gh-issue-149221.QVCmhr.rst
+++ b/Misc/NEWS.d/next/Library/2026-06-06-18-57-00.gh-issue-149221.QVCmhr.rst
@@ -1,0 +1,3 @@
+:meth:`random.Random.binomialvariate` no longer raises :exc:`ValueError`
+when the underlying :meth:`~random.Random.random` returns ``0.0`` while sampling
+with ``n * p < 10``.


### PR DESCRIPTION
Summary:
- Fix `random.binomialvariate()` raising `ValueError: math domain error` when the underlying `random()` returns `0.0` (a value within its documented range `[0.0, 1.0)`). It occurs in the BG geometric branch (`n * p < 10`) where `log2(random())` is evaluated.
- Add a regression test for the `random() == 0.0` case.

Tests:
- `./python -m test test_random -m '*binomialvariate*'`

---
_Generated by [Claude Code](https://claude.ai/code/session_019aJ7pxZ6gNWzXmYT5obbvN)_