### PR TITLE
Fix email header folding exceeding max_line_length on continuation lines

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -3001,6 +3001,13 @@ def _fold_as_ew(to_encode, lines, maxlen, last_ew, ew_combine_allowed, charset, 
             encoded_word = _ew.encode(leading_whitespace, charset=encode_as)
             lines[-1] += encoded_word
             leading_whitespace = ''
+            # The leading whitespace was encoded as its own encoded word and
+            # appended to the line, so recompute the space left on the line.
+            remaining_space = maxlen - len(lines[-1])
+            text_space = remaining_space - chrome_len
+            if text_space <= 0:
+                lines.append(' ')
+                continue
 
         to_encode_word = to_encode[:text_space]
         encoded_word = _ew.encode(to_encode_word, charset=encode_as)

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -3123,6 +3123,21 @@ class TestFolding(TestEmailBase):
                                            "=?unknown-8bit?q?=A4?="),
                    prefix + "=?unknown-8bit?q?=C2?=\n =?unknown-8bit?q?=A4?=\n")
 
+    def test_long_ew_after_encoded_continuation_whitespace(self):
+        # When an encoded word begins a continuation line, the line's leading
+        # whitespace is emitted as its own encoded word.  The space it consumes
+        # must be subtracted from the budget, otherwise the following encoded
+        # word overflows max_line_length.
+        policy = self.policy.clone(max_line_length=40)
+        self._test(parser.get_unstructured(
+            'a b c d ä d .,ä,  dc cbaö,ä.,baaöa üa.,ü,c,äöäa,bööüc üü'),
+            'a b c d =?utf-8?b?w6QgZCAuLMOkLA==?=  dc\n'
+            ' =?utf-8?q?_?==?utf-8?b?Y2Jhw7Ysw6Qu?=\n'
+            ' =?utf-8?b?LGJhYcO2YSDDvGEuLMO8LGMs?=\n'
+            ' =?utf-8?b?w6TDtsOkYSxiw7bDtsO8YyA=?=\n'
+            ' =?utf-8?q?=C3=BC=C3=BC?=\n',
+            policy=policy)
+
     # XXX Need test of an encoded word so long that it needs to be wrapped
 
     def test_simple_address(self):


### PR DESCRIPTION
Summary:
- Fix `_fold_as_ew()` exceeding `max_line_length` when an encoded word starts a continuation line whose leading whitespace is itself encoded: the leading-whitespace encoded word was appended to the line but `remaining_space`/`text_space` were not updated, so the next encoded word was sized against a stale budget and overflowed.
- Add a regression test for the leading-whitespace continuation overflow case.

Tests:
- `./python -m unittest test.test_email.test__header_value_parser.TestFolding.test_long_ew_after_encoded_continuation_whitespace`
- `./python -m unittest test.test_email`

---
_Generated by [Claude Code](https://claude.ai/code/session_019aJ7pxZ6gNWzXmYT5obbvN)_